### PR TITLE
Increase timeout for Windows CI and clean up clone command

### DIFF
--- a/git-clone-related
+++ b/git-clone-related
@@ -153,7 +153,7 @@ else
   timeout 300 git clone -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
     || { sleep 60 \
          && { timeout 300 git clone -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
-              || { echo "git-clone-related: failed: git clone --depth 300 -b ${REPO_BRANCH}" "$@" "${REPO_URL} ${DESTINATION}";
+              || { echo "git-clone-related: failed: git clone -b ${REPO_BRANCH}" "$@" "${REPO_URL} ${DESTINATION}";
                    exit 2; } } }
 fi
 echo "git-clone-related: ${DESTINATION} is at $(cd "${DESTINATION}" && git rev-parse HEAD)"

--- a/git-clone-related
+++ b/git-clone-related
@@ -150,9 +150,9 @@ else
   fi
   echo "About to run: git clone -b ${REPO_BRANCH} $* ${REPO_URL} ${DESTINATION}"
   # Try twice in case of network lossage.
-  timeout 200 git clone -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
+  timeout 300 git clone -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
     || { sleep 60 \
-         && { timeout 200 git clone -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
+         && { timeout 300 git clone -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
               || { echo "git-clone-related: failed: git clone --depth 1 -b ${REPO_BRANCH}" "$@" "${REPO_URL} ${DESTINATION}";
                    exit 2; } } }
 fi

--- a/git-clone-related
+++ b/git-clone-related
@@ -150,9 +150,9 @@ else
   fi
   echo "About to run: git clone -b ${REPO_BRANCH} $* ${REPO_URL} ${DESTINATION}"
   # Try twice in case of network lossage.
-  timeout 60 git clone --depth 1 -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
+  timeout 200 git clone -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
     || { sleep 60 \
-         && { timeout 60 git clone --depth 1 -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
+         && { timeout 200 git clone -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
               || { echo "git-clone-related: failed: git clone --depth 1 -b ${REPO_BRANCH}" "$@" "${REPO_URL} ${DESTINATION}";
                    exit 2; } } }
 fi

--- a/git-clone-related
+++ b/git-clone-related
@@ -153,7 +153,7 @@ else
   timeout 300 git clone -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
     || { sleep 60 \
          && { timeout 300 git clone -b "${REPO_BRANCH}" "$@" "${REPO_URL}" "${DESTINATION}" \
-              || { echo "git-clone-related: failed: git clone --depth 1 -b ${REPO_BRANCH}" "$@" "${REPO_URL} ${DESTINATION}";
+              || { echo "git-clone-related: failed: git clone --depth 300 -b ${REPO_BRANCH}" "$@" "${REPO_URL} ${DESTINATION}";
                    exit 2; } } }
 fi
 echo "git-clone-related: ${DESTINATION} is at $(cd "${DESTINATION}" && git rev-parse HEAD)"


### PR DESCRIPTION
**Timeout parameter change** 

[Windows CI](https://github.com/eisop/checker-framework/actions/runs/15567268711/job/43834296987) took a strange long time (178 seconds) to clone the JDK, while [MacOS CI](https://github.com/eisop/checker-framework/actions/runs/15567268711/job/43834296986) only take 14 seconds. I also tried timeout parameter as  `200s` , but did not work. So I changed the timeout to 300s in this PR.

My test for Windows CI:
```
++ date +%s
+ end=1749580163
+ echo 'Duration: 178 seconds'
Duration: 178 seconds
``` 

My test for MacOS CI:
```
++ date +%s
+ end=1749579858
Duration: 14 seconds
+ echo 'Duration: 14 seconds'
```

**Clone command change**

Remove `--depth 1` is a clean up as we already have it in the `"$@"`.
Otherwise, it would be a redundant command. 

Example from the CI log:
```
+ timeout 60 git clone --depth 1 -b master -q --single-branch --depth 1 https://github.com/eisop/jdk.git ../jdk
```

