### PR TITLE
Use eisop plume-scripts in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ clean:
 
 # Code style; defines `style-check` and `style-fix`.
 ifeq (,$(wildcard .plume-scripts))
-dummy := $(shell git clone --depth=1 -q https://github.com/plume-lib/plume-scripts.git .plume-scripts)
+dummy := $(shell git clone --depth=1 -q https://github.com/eisop-plume-lib/plume-scripts.git .plume-scripts)
 endif
 include .plume-scripts/code-style.mak


### PR DESCRIPTION
This will fix the CI failure because upstream uses CI_BRANCH instead of CI_BRANCH_NAME, see https://github.com/plume-lib/plume-scripts/blob/a634136edcbe0a066a4e3e7dc70cc4b489f0ffcf/ci-info#L247.

We still use CI_BRANCH_NAME, see https://github.com/eisop-plume-lib/git-scripts/blob/be37e88f9dd18e6d4bbfa2eeb6c36e1187b5790f/git-clone-related#L168.